### PR TITLE
Fix Travel Section fields not being repopulated

### DIFF
--- a/src/components/form/ApplicationForm/ConsentSection.tsx
+++ b/src/components/form/ApplicationForm/ConsentSection.tsx
@@ -90,8 +90,6 @@ const ConsentSection = ({
 
 	useEffect(() => {
 		if (fetchedProfile) {
-			console.log(consentFields);
-
 			setTartanhacksCodeOfConduct(consentFields.tartanHacksCodeOfConductAcknowledgement);
 			setMediaRelease(consentFields.tartanHacksMediaReleaseAcknowledgement);
 			setSignature(consentFields.tartanHacksMediaReleaseSignature);

--- a/src/components/form/ApplicationForm/TravelSection.tsx
+++ b/src/components/form/ApplicationForm/TravelSection.tsx
@@ -12,9 +12,10 @@ import React, {
 	useEffect,
 	useState,
 } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import actions from 'src/actions';
 import { TravelFields } from 'types/ApplicationForm';
+import { RootState } from 'types/RootState';
 import styles from './index.module.scss';
 
 const TravelSection = ({
@@ -27,6 +28,12 @@ const TravelSection = ({
 	setValid: Dispatch<SetStateAction<boolean>>;
 }): ReactElement => {
 	const dispatch = useDispatch();
+
+	const fetchedProfile = useSelector(
+		(state: RootState) => state?.application?.fetchedProfile,
+	);
+	const travelFields =
+		useSelector((state: RootState) => state?.application?.travel) ?? {};
 
 	const [wantsTravelReimbursement, setWantsTravelReimbursement] = useState<boolean>(false);
 	const [travelDetails, setTravelDetails] = useState<string>('');
@@ -56,6 +63,14 @@ const TravelSection = ({
 		}
 		// eslint-disable-next-line
 	}, [validate]);
+
+	useEffect(() => {
+		if (fetchedProfile) {
+			setWantsTravelReimbursement(travelFields.wantsTravelReimbursement);
+			setTravelDetails(travelFields.travelDetails ?? "");
+		}
+		// eslint-disable-next-line
+	}, [fetchedProfile]);
 
 	const maxChars = 100;
 


### PR DESCRIPTION
# Description

Saved profile did not repopulate the travel reimbursement application fields. Fixed by adding code to repopulate based on whether an existing profile was fetched.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Local testing

**Test Configuration**:

<!-- Please remove sections that are not relevant. -->

- Node.js version: 20
- Desktop/Mobile: Desktop
- OS: MacOS
- Browser: Arc