### PR TITLE
Fix admin panel for easier reviewing

### DIFF
--- a/src/components/admin/AdminDialog/index.module.scss
+++ b/src/components/admin/AdminDialog/index.module.scss
@@ -3,7 +3,7 @@
 
 .dialog {
 	width: 100%;
-	height: 100%;
+	height: 80%;
 	display: flex;
 	align-items: center;
 	justify-content: center;

--- a/src/components/form/ApplicationForm/TravelSection.tsx
+++ b/src/components/form/ApplicationForm/TravelSection.tsx
@@ -77,6 +77,7 @@ const TravelSection = ({
 				<FormControlLabel
 					control={
 						<Checkbox
+							disabled
 							value={wantsTravelReimbursement}
 							checked={wantsTravelReimbursement}
 							onChange={(e, checked) => setWantsTravelReimbursement(checked)}
@@ -97,6 +98,7 @@ const TravelSection = ({
 				helperText={travelInfoHelper}
 				fullWidth
 				multiline
+				disabled
 				value={travelDetails}
 				onChange={(e) => {
 					setTravelDetails(e.target.value.slice(0, maxChars));

--- a/src/components/form/ApplicationForm/TravelSection.tsx
+++ b/src/components/form/ApplicationForm/TravelSection.tsx
@@ -77,7 +77,6 @@ const TravelSection = ({
 				<FormControlLabel
 					control={
 						<Checkbox
-							disabled
 							value={wantsTravelReimbursement}
 							checked={wantsTravelReimbursement}
 							onChange={(e, checked) => setWantsTravelReimbursement(checked)}
@@ -98,7 +97,6 @@ const TravelSection = ({
 				helperText={travelInfoHelper}
 				fullWidth
 				multiline
-				disabled
 				value={travelDetails}
 				onChange={(e) => {
 					setTravelDetails(e.target.value.slice(0, maxChars));


### PR DESCRIPTION
# Description

Change admin dialog height to 80% from 100% so that analytics page does not have nav bar cut off.

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Local testing.

**Test Configuration**:

<!-- Please remove sections that are not relevant. -->

- Node.js version: 20
- Desktop/Mobile: Desktop
- OS: MacOS
- Browser: Arc